### PR TITLE
Update README.md to state how to support the older ERCF-Software-V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ EREC uses the awesome Happy Hare firmware for the ERCF. I'm sure this also works
 </tr>
 </table>
 
+#### Support for the Older ERCF software ERCF-Software-V3
+For people still using the original ERCF-Software-V3, the older Enraged Rabbit software and not ready to upgrade to Happy Hare yet, unfortunately the cutter feature is not supported, because cutter need some new API/macro the older software doesn't have or not exposed.
+
+However, this fork/branch of the ERCF software V3 has some additional work done especially for this ERCF cutter, so it can support this feature.
+Sample config files are also available for easy configuration.
+
+[special edition of ERCF-Software-V3 for ERCF cutter ](https://github.com/ntchris/ERCF-Software-V3)
+
 <br>
 
 ## Acknowledgements


### PR DESCRIPTION
Update README.md to state how to support the older ERCF-Software-V3

As stated in the readme content,
the original ERCF-Software-V3 doesn't support this cutter feature. 
but because that special editoin/branch/fork's author really like the cutter mod, 
so he spent quite some time to add support in the ERCF-software-V3 for cutter.
So adding this piece of info in the readme, hopefully people still running the older ERCF sw V3 can use this good cutter feature without upgrading to the happy hare.
https://github.com/ntchris/ERCF-Software-V3